### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.1 - Unreleased
+## 0.5.1 - 2026-05-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.1 - Unreleased
+
+### Fixed
+
+- Fixes NIF source navigation so the source dropdown and arrow buttons follow
+  MO2 conflict priority from winning mod to losing mod, with game archives last.
+
 ## 0.5.0 - 2026-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Fixed
 
-- Fixes NIF source navigation so the source dropdown and arrow buttons follow
-  MO2 conflict priority from winning mod to losing mod, with game archives last.
+- Fixes NIF and texture source navigation so the dropdowns and arrow buttons
+  follow MO2 conflict priority from winning mod to losing mod, with game
+  archives last.
 
 ## 0.5.0 - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.1 - Unreleased
 
+### Added
+
+- Persists the split preview toggle per MO2 profile.
+
 ### Fixed
 
 - Fixes NIF and texture source navigation so the dropdowns and arrow buttons

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 set(VCPKG_TARGET_TRIPLET "x64-windows-static-md" CACHE STRING "vcpkg target triplet")
 set(VCPKG_MANIFEST_NO_DEFAULT_FEATURES ON CACHE BOOL "Use only default vcpkg manifest dependencies")
 
-set(PREVIEW_NIF_RELEASE_VERSION "0.5.0" CACHE STRING "NIF Preview release version")
+set(PREVIEW_NIF_RELEASE_VERSION "0.5.1" CACHE STRING "NIF Preview release version")
 
 project(preview_nif VERSION ${PREVIEW_NIF_RELEASE_VERSION})
 

--- a/plugindefinition.json
+++ b/plugindefinition.json
@@ -7,6 +7,38 @@
   "NexusUrl": "https://www.nexusmods.com/skyrimspecialedition/mods/137741",
   "Versions": [
     {
+      "Version": "0.5.1.0b",
+      "Released": "2026-05-14",
+      "MinSupport": "2.5.3",
+      "MaxSupport": "2.5.3",
+      "MinWorking": "2.5.3",
+      "MaxWorking": "",
+      "DownloadUrl": "https://github.com/gabriel-andreescu/modorganizer-preview_nif/releases/download/0.5.1/NIF.Preview.MO2-2.5.3beta11.zip",
+      "PluginPath": [
+        "preview_nif.dll",
+        "data"
+      ],
+      "LocalePath": [],
+      "DataPath": [],
+      "ReleaseNotes": []
+    },
+    {
+      "Version": "0.5.1.0b",
+      "Released": "2026-05-14",
+      "MinSupport": "2.5.2",
+      "MaxSupport": "2.5.2",
+      "MinWorking": "2.5.2",
+      "MaxWorking": "",
+      "DownloadUrl": "https://github.com/gabriel-andreescu/modorganizer-preview_nif/releases/download/0.5.1/NIF.Preview.MO2-2.5.2.zip",
+      "PluginPath": [
+        "preview_nif.dll",
+        "data"
+      ],
+      "LocalePath": [],
+      "DataPath": [],
+      "ReleaseNotes": []
+    },
+    {
       "Version": "0.5.0.0b",
       "Released": "2026-05-11",
       "MinSupport": "2.5.3",

--- a/src/NifPreviewPane.cpp
+++ b/src/NifPreviewPane.cpp
@@ -97,10 +97,10 @@ NifPreviewPane::NifPreviewPane(MOBase::IOrganizer* organizer, QWidget* parent)
     rootLayout->addWidget(m_StatsLabel);
 
     connect(m_PrevButton, &QToolButton::clicked, this, [this]() {
-        selectRelativeProvider(-1);
+        selectRelativeProvider(1);
     });
     connect(m_NextButton, &QToolButton::clicked, this, [this]() {
-        selectRelativeProvider(1);
+        selectRelativeProvider(-1);
     });
     connect(m_SourceCombo, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](const int index) {
         if (!m_UpdatingControls) {

--- a/src/NifPreviewPane.cpp
+++ b/src/NifPreviewPane.cpp
@@ -108,10 +108,10 @@ NifPreviewPane::NifPreviewPane(MOBase::IOrganizer* organizer, QWidget* parent)
         }
     });
     connect(m_PrevTextureButton, &QToolButton::clicked, this, [this]() {
-        selectRelativeTextureSource(-1);
+        selectRelativeTextureSource(1);
     });
     connect(m_NextTextureButton, &QToolButton::clicked, this, [this]() {
-        selectRelativeTextureSource(1);
+        selectRelativeTextureSource(-1);
     });
     connect(m_TextureSourceCombo, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](const int index) {
         if (!m_UpdatingTextureControls) {

--- a/src/NifPreviewSource.cpp
+++ b/src/NifPreviewSource.cpp
@@ -6,6 +6,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QObject>
+#include <QStringList>
 
 #include <algorithm>
 #include <filesystem>
@@ -237,6 +238,14 @@ void addGameArchiveProviders(
     }
 }
 
+void orderOriginsForPreview(QStringList& origins) {
+    // MO2 returns the primary winner first, then alternatives in losing-to-winning order.
+    // Keep the winner first and present the alternatives from strongest to weakest.
+    if (origins.size() > 1) {
+        std::reverse(origins.begin() + 1, origins.end());
+    }
+}
+
 int providerIndexForPath(const QVector<NifPreviewProvider>& providers, const QString& path) {
     if (path.isEmpty()) {
         return -1;
@@ -304,7 +313,8 @@ NifPreviewSourceSet NifPreviewSourceResolver::resolve(
     const auto normalizedFileName = QDir::fromNativeSeparators(fileName);
     if (organizer && !sourceSet.virtualPath.isEmpty()) {
         if (auto* const modList = organizer->modList()) {
-            const auto origins = organizer->getFileOrigins(sourceSet.virtualPath);
+            auto origins = organizer->getFileOrigins(sourceSet.virtualPath);
+            orderOriginsForPreview(origins);
             for (const auto& modName : origins) {
                 auto* const mod = modList->getMod(modName);
                 if (!mod) {

--- a/src/NifPreviewWidget.cpp
+++ b/src/NifPreviewWidget.cpp
@@ -3,20 +3,47 @@
 #include "NifPreviewPane.h"
 
 #include <QCheckBox>
+#include <QDir>
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QPushButton>
+#include <QSettings>
 #include <QSharedPointer>
 #include <QShowEvent>
+#include <QSignalBlocker>
 #include <QSplitter>
 #include <QTimer>
 #include <QVBoxLayout>
 
+#include <uibase/imoinfo.h>
 #include <utility>
 
 namespace {
+constexpr auto ProfileSettingsFileName = "preview_nif.ini";
+constexpr auto ProfileSettingsGroup = "Preview";
+constexpr auto SplitPreviewSettingKey = "splitPreview";
+
 QSharedPointer<Camera> makePreviewCamera() {
     return {new Camera(), &Camera::deleteLater};
+}
+
+QString profileSettingsPath(MOBase::IOrganizer* organizer) {
+    if (!organizer || organizer->profilePath().isEmpty()) {
+        return {};
+    }
+
+    return QDir(organizer->profilePath()).filePath(ProfileSettingsFileName);
+}
+
+bool splitViewPreference(MOBase::IOrganizer* organizer) {
+    const auto settingsPath = profileSettingsPath(organizer);
+    if (settingsPath.isEmpty()) {
+        return false;
+    }
+
+    QSettings settings(settingsPath, QSettings::IniFormat);
+    settings.beginGroup(ProfileSettingsGroup);
+    return settings.value(SplitPreviewSettingKey, false).toBool();
 }
 } // namespace
 
@@ -27,6 +54,7 @@ NifPreviewWidget::NifPreviewWidget(
     QWidget* parent
 )
     : QWidget(parent)
+    , m_Organizer(organizer)
     , m_SourceSet(std::move(sourceSet)) {
     m_GlobalControlsWidget = new QFrame(this);
     m_GlobalControlsWidget->setObjectName("nifPreviewGlobalToolbar");
@@ -74,7 +102,9 @@ NifPreviewWidget::NifPreviewWidget(
     rootLayout->addWidget(m_GlobalControlsWidget);
     rootLayout->addWidget(m_Splitter, 1);
 
-    connect(m_SplitButton, &QCheckBox::toggled, this, &NifPreviewWidget::setSplitViewEnabled);
+    connect(m_SplitButton, &QCheckBox::toggled, this, [this](const bool enabled) {
+        setSplitViewEnabled(enabled, true);
+    });
     connect(m_ShowCollisionButton, &QCheckBox::toggled, this, &NifPreviewWidget::setShowCollisionEnabled);
     connect(m_CameraSyncButton, &QCheckBox::toggled, this, &NifPreviewWidget::setCameraSyncEnabled);
     connect(m_ResetCameraButton, &QPushButton::clicked, this, &NifPreviewWidget::resetCameras);
@@ -85,6 +115,7 @@ NifPreviewWidget::NifPreviewWidget(
         handleCameraMoved(m_RightPane);
     });
 
+    restoreSplitViewPreference();
     updateGlobalControls();
 }
 
@@ -97,8 +128,13 @@ void NifPreviewWidget::showEvent(QShowEvent* event) {
     QTimer::singleShot(0, this, &NifPreviewWidget::updateHostChrome);
 }
 
-void NifPreviewWidget::setSplitViewEnabled(const bool enabled) {
+void NifPreviewWidget::setSplitViewEnabled(const bool enabled, const bool persistPreference) {
+    if (persistPreference) {
+        saveSplitViewPreference(enabled);
+    }
+
     if (enabled && m_SourceSet.providers.size() < 2) {
+        const QSignalBlocker blocker(m_SplitButton);
         m_SplitButton->setChecked(false);
         return;
     }
@@ -120,13 +156,40 @@ void NifPreviewWidget::setSplitViewEnabled(const bool enabled) {
     updateHostChrome();
 }
 
+void NifPreviewWidget::restoreSplitViewPreference() {
+    if (!splitViewPreference(m_Organizer)) {
+        return;
+    }
+
+    const QSignalBlocker blocker(m_SplitButton);
+    m_SplitButton->setChecked(true);
+    setSplitViewEnabled(true, false);
+    m_SplitButton->setChecked(isSplitViewEnabled());
+}
+
+void NifPreviewWidget::saveSplitViewPreference(const bool enabled) const {
+    const auto settingsPath = profileSettingsPath(m_Organizer);
+    if (settingsPath.isEmpty()) {
+        return;
+    }
+
+    QSettings settings(settingsPath, QSettings::IniFormat);
+    settings.beginGroup(ProfileSettingsGroup);
+    settings.setValue(SplitPreviewSettingKey, enabled);
+    settings.sync();
+}
+
+bool NifPreviewWidget::isSplitViewEnabled() const {
+    return m_RightPane && !m_RightPane->isHidden();
+}
+
 void NifPreviewWidget::setShowCollisionEnabled(const bool enabled) {
     m_LeftPane->setShowCollision(enabled);
     m_RightPane->setShowCollision(enabled);
 }
 
 void NifPreviewWidget::setCameraSyncEnabled(const bool enabled) {
-    if (!m_RightPane->isVisible() && enabled) {
+    if (!isSplitViewEnabled() && enabled) {
         return;
     }
 
@@ -139,7 +202,7 @@ void NifPreviewWidget::setCameraSyncEnabled(const bool enabled) {
 
 void NifPreviewWidget::resetCameras() {
     m_ApplyingCameraSync = true;
-    if (!m_RightPane->isVisible()) {
+    if (!isSplitViewEnabled()) {
         m_LeftPane->resetCamera();
         m_ApplyingCameraSync = false;
         updateCameraSnapshot(m_LeftPane);
@@ -161,7 +224,7 @@ void NifPreviewWidget::updateGlobalControls() {
                       "versions of this NIF")
     );
 
-    const auto splitActive = m_RightPane->isVisible();
+    const auto splitActive = isSplitViewEnabled();
     m_CameraSyncButton->setVisible(splitActive);
     m_CameraSyncButton->setEnabled(splitActive);
 
@@ -210,7 +273,7 @@ void NifPreviewWidget::handleCameraMoved(NifPreviewPane* pane) {
 
     const auto newState = pane->camera()->state();
 
-    if (!m_ApplyingCameraSync && m_CameraSyncButton->isChecked() && m_RightPane->isVisible()) {
+    if (!m_ApplyingCameraSync && m_CameraSyncButton->isChecked() && isSplitViewEnabled()) {
         syncCameraDelta(pane, newState);
     }
 

--- a/src/NifPreviewWidget.h
+++ b/src/NifPreviewWidget.h
@@ -34,10 +34,13 @@ protected:
     void showEvent(QShowEvent* event) override;
 
 private:
-    void setSplitViewEnabled(bool enabled);
+    void setSplitViewEnabled(bool enabled, bool persistPreference);
     void setShowCollisionEnabled(bool enabled);
     void setCameraSyncEnabled(bool enabled);
     void resetCameras();
+    void restoreSplitViewPreference();
+    void saveSplitViewPreference(bool enabled) const;
+    [[nodiscard]] bool isSplitViewEnabled() const;
     void updateGlobalControls();
     void updateHostChrome();
     void initializeRightPaneForSplit();
@@ -48,6 +51,7 @@ private:
     [[nodiscard]] PreviewPaneSide sideForPane(NifPreviewPane* pane) const;
     [[nodiscard]] int secondaryProviderIndex() const;
 
+    MOBase::IOrganizer* m_Organizer = nullptr;
     NifPreviewSourceSet m_SourceSet;
 
     QFrame* m_GlobalControlsWidget = nullptr;

--- a/src/PreviewNif.cpp
+++ b/src/PreviewNif.cpp
@@ -25,7 +25,7 @@ QString PreviewNif::description() const {
 }
 
 MOBase::VersionInfo PreviewNif::version() const {
-    return {0, 5, 0, 0, MOBase::VersionInfo::RELEASE_BETA};
+    return {0, 5, 1, 0, MOBase::VersionInfo::RELEASE_BETA};
 }
 
 QList<MOBase::PluginSetting> PreviewNif::settings() const {

--- a/src/TextureSource.cpp
+++ b/src/TextureSource.cpp
@@ -459,6 +459,16 @@ TextureSourceProvider makeProvider(
     );
     return provider;
 }
+
+void orderModsByProfilePriority(QStringList& modOrder, MOBase::IModList* modList) {
+    if (!modList || modOrder.size() < 2) {
+        return;
+    }
+
+    std::stable_sort(modOrder.begin(), modOrder.end(), [&](const QString& lhs, const QString& rhs) {
+        return modList->priority(lhs) > modList->priority(rhs);
+    });
+}
 } // namespace
 
 QString normalizeTextureDataPath(QString path) {
@@ -553,6 +563,7 @@ TextureSourceSet TextureSourceResolver::resolve(MOBase::IOrganizer* organizer, c
         }
     }
 
+    orderModsByProfilePriority(modOrder, modList);
     for (const auto& modName : modOrder) {
         const auto& builder = modBuilders[modName];
         if (!builder.coveredTextureKeys.isEmpty()) {

--- a/src/preview_nif_en.ts
+++ b/src/preview_nif_en.ts
@@ -112,7 +112,7 @@
     </message>
     <message>
         <location filename="NifPreviewSource.cpp" line="234"/>
-        <location filename="TextureSource.cpp" line="566"/>
+        <location filename="TextureSource.cpp" line="577"/>
         <source>Game Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -243,47 +243,47 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TextureSource.cpp" line="522"/>
+        <location filename="TextureSource.cpp" line="532"/>
         <source>Auto: MO2 winners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TextureSource.cpp" line="589"/>
+        <location filename="TextureSource.cpp" line="600"/>
         <source>Textures: none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TextureSource.cpp" line="596"/>
+        <location filename="TextureSource.cpp" line="607"/>
         <source>%1 +%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TextureSource.cpp" line="599"/>
+        <location filename="TextureSource.cpp" line="610"/>
         <source>Textures: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TextureSource.cpp" line="604"/>
+        <location filename="TextureSource.cpp" line="615"/>
         <source>No referenced textures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TextureSource.cpp" line="610"/>
+        <location filename="TextureSource.cpp" line="621"/>
         <source>Texture source: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TextureSource.cpp" line="612"/>
+        <location filename="TextureSource.cpp" line="623"/>
         <source>Texture slots: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TextureSource.cpp" line="613"/>
+        <location filename="TextureSource.cpp" line="624"/>
         <source>Referenced textures:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TextureSource.cpp" line="615"/>
+        <location filename="TextureSource.cpp" line="626"/>
         <source>%1: %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/preview_nif_en.ts
+++ b/src/preview_nif_en.ts
@@ -37,60 +37,60 @@
 <context>
     <name>NifPreviewWidget</name>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="36"/>
-        <location filename="NifPreviewWidget.cpp" line="168"/>
+        <location filename="NifPreviewWidget.cpp" line="64"/>
+        <location filename="NifPreviewWidget.cpp" line="231"/>
         <source>Reset Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="37"/>
-        <location filename="NifPreviewWidget.cpp" line="169"/>
+        <location filename="NifPreviewWidget.cpp" line="65"/>
+        <location filename="NifPreviewWidget.cpp" line="232"/>
         <source>Reset the preview camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="39"/>
+        <location filename="NifPreviewWidget.cpp" line="67"/>
         <source>Show Collision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="40"/>
+        <location filename="NifPreviewWidget.cpp" line="68"/>
         <source>Show collision preview overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="42"/>
+        <location filename="NifPreviewWidget.cpp" line="70"/>
         <source>Split Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="43"/>
-        <location filename="NifPreviewWidget.cpp" line="159"/>
+        <location filename="NifPreviewWidget.cpp" line="71"/>
+        <location filename="NifPreviewWidget.cpp" line="222"/>
         <source>Compare two previewable versions of this NIF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="45"/>
+        <location filename="NifPreviewWidget.cpp" line="73"/>
         <source>Sync Cameras</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="46"/>
+        <location filename="NifPreviewWidget.cpp" line="74"/>
         <source>Synchronize cameras between preview panes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="160"/>
+        <location filename="NifPreviewWidget.cpp" line="223"/>
         <source>Split view requires at least two previewable versions of this NIF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="168"/>
+        <location filename="NifPreviewWidget.cpp" line="231"/>
         <source>Reset Cameras</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewWidget.cpp" line="169"/>
+        <location filename="NifPreviewWidget.cpp" line="232"/>
         <source>Reset both preview cameras</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/preview_nif_en.ts
+++ b/src/preview_nif_en.ts
@@ -106,23 +106,23 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="NifPreviewSource.cpp" line="153"/>
+        <location filename="NifPreviewSource.cpp" line="154"/>
         <source>%1 - %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewSource.cpp" line="233"/>
+        <location filename="NifPreviewSource.cpp" line="234"/>
         <location filename="TextureSource.cpp" line="566"/>
         <source>Game Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewSource.cpp" line="329"/>
+        <location filename="NifPreviewSource.cpp" line="339"/>
         <source>Current Archive Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NifPreviewSource.cpp" line="399"/>
+        <location filename="NifPreviewSource.cpp" line="409"/>
         <source>Verts: %1 | Faces: %2 | Shapes: %3</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
## Summary
- Fix NIF and texture source navigation ordering so source selectors follow MO2 conflict priority from winning mod to losing mod, with game archives last.
- Persist the split preview toggle per MO2 profile and restore the checked UI state on restart.
- Prepare the 0.5.1 release metadata, plugin version, and plugin finder entries.

## Validation
- Built release ZIPs for MO2 2.5.2 and MO2 2.5.3beta11.
- Deployed both ZIPs to local matching MO2 installs.
- Verified each deployed `preview_nif.dll` hash matches the DLL packaged in its release ZIP.